### PR TITLE
chore: use trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
     # Go
     steps:
     - name: Check out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -48,7 +48,7 @@ jobs:
     - name: Notify
       uses: sarisia/actions-status-discord@v1
       # Only fire alert once
-      if: github.ref == 'refs/heads/main' && failure() && matrix.node-version == '14.x' && matrix.os == 'ubuntu-latest'
+      if: github.ref == 'refs/heads/main' && failure() && matrix.node-version == '24.x' && matrix.os == 'ubuntu-latest'
       with:
         webhook: ${{ secrets.DISCORD_WEBHOOK }}
         title: "build and test"
@@ -60,6 +60,9 @@ jobs:
   # Publish to package registries
   publish:
     # Setup
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: read
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
@@ -67,12 +70,12 @@ jobs:
     # Go
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24.x
           registry-url: https://registry.npmjs.org/
 
       # - name: Install
@@ -82,20 +85,16 @@ jobs:
       - name: Publish @RC to npm
         if: contains(github.ref, 'RC')
         run: npm publish --tag RC
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @latest to npm
         if: contains(github.ref, 'RC') == false #'!contains()'' doesn't work lol
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Set up Node again, this time using GitHub as the publish target
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24.x
           registry-url: https://npm.pkg.github.com/
 
       - name: Notify


### PR DESCRIPTION
Set up the trusted publisher thing on npmjs settings: https://www.npmjs.com/package/lambda-runtimes/access